### PR TITLE
Replacing etp.kit.edu config with symlink to ekp.kit.edu config

### DIFF
--- a/config/etp.kit.edu.conf
+++ b/config/etp.kit.edu.conf
@@ -1,7 +1,1 @@
-[global]
-backend = condor
-
-[condor]
-; Map GridControl values to corresponding ETP Condor values
-poolArgs req =
-	walltimeMin => +RequestWalltime
+ekp.kit.edu.conf


### PR DESCRIPTION
This pull request replaces the dedicated etp.kit.edu config with a symlink to the ekp.kit.edu config. As done for the physik.uni-karlsruhe.de config this ensures the config is inline for the resources belonging to ETP, independent of the fqdn and resulting config.

Please note, this re-enables setting the "Input_Files" ClassAd for the respective jobs. In the current state and setup this does not infer with the jobs, but allows to use information from the jobs for studying caching approaches and in future will be necessary for using this.